### PR TITLE
fix puppet install, add access to OS_VERS input var

### DIFF
--- a/Puppetlabs/Puppet-Agent.install.recipe
+++ b/Puppetlabs/Puppet-Agent.install.recipe
@@ -1,29 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>Description</key>
-        <string>Uses parent pkg recipe to download latest Puppet-Agent and installs it.</string>
-        <key>Identifier</key>
-        <string>com.github.grahamgilbert.install.puppet-agent</string>
-        <key>MinimumVersion</key>
-        <string>0.4.0</string>
-        <key>ParentRecipe</key>
-        <string>com.github.autopkg.download.puppet-agent</string>
-        <key>Input</key>
-        <dict>
-        </dict>
-        <key>Process</key>
-        <array>
-            <dict>
-                <key>Processor</key>
-                <string>Installer</string>
-                <key>Arguments</key>
-                <dict>
-                    <key>pkg_path</key>
-                    <string>%pathname%</string>
-                </dict>
-            </dict>
-        </array>
-    </dict>
+	<dict>
+		<key>Description</key>
+		<string>Uses parent pkg recipe to download latest Puppet-Agent and installs it.</string>
+		<key>Identifier</key>
+		<string>com.github.grahamgilbert.install.puppet-agent</string>
+		<key>MinimumVersion</key>
+		<string>0.4.0</string>
+		<key>ParentRecipe</key>
+		<string>com.github.autopkg.download.puppet-agent</string>
+		<key>Input</key>
+		<dict>
+			<key>OS_VERSION</key>
+			<string>10.12</string>
+		</dict>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Processor</key>
+				<string>Installer</string>
+				<key>Arguments</key>
+				<dict>
+					<key>pkg_path</key>
+					<string>%pathname%/*.pkg</string>
+				</dict>
+			</dict>
+		</array>
+	</dict>
 </plist>


### PR DESCRIPTION
pkg_path variable was incorrect. Previously this didn't include
explicit access to the parent's OS_VERSION input variable, also
converted space to tabs because xml