### PR TITLE
Add post install to gracefully kill running buildkite instances

### DIFF
--- a/Buildkite/BuildkiteAgent.munki.recipe
+++ b/Buildkite/BuildkiteAgent.munki.recipe
@@ -22,6 +22,11 @@
             </array>
             <key>name</key>
             <string>%NAME%</string>
+            <key>postinstall_script</key>
+            <string>#!/bin/bash
+ killall buildkite-agent
+ exit 0
+            </string>
             <key>unattended_install</key>
             <true/>
         </dict>


### PR DESCRIPTION
When the `buildkite-agent` receives a SIGINT or SIGTERM it will gracefully terminate, i.e. wait until any running builds are finished and then kill the process. If it receives another, it'll immediately terminate. Paired with the appropriate launchd setup, this postinstall_script should cause the `buildkite-agent` to gracefully terminate and then launchd, seeing it's gone will start up a new process with the new version.

@grahamgilbert 