### PR TITLE
Update buildkite postinstall to not kill too broadly

### DIFF
--- a/Buildkite/BuildkiteAgent.munki.recipe
+++ b/Buildkite/BuildkiteAgent.munki.recipe
@@ -24,7 +24,7 @@
             <string>%NAME%</string>
             <key>postinstall_script</key>
             <string>#!/bin/bash
-pid=$(pgrep -f "buildkite-agent start") && kill $pid
+pkill -f "buildkite-agent start"
 exit 0
             </string>
             <key>unattended_install</key>

--- a/Buildkite/BuildkiteAgent.munki.recipe
+++ b/Buildkite/BuildkiteAgent.munki.recipe
@@ -24,8 +24,8 @@
             <string>%NAME%</string>
             <key>postinstall_script</key>
             <string>#!/bin/bash
- killall buildkite-agent
- exit 0
+pid=$(pgrep -f "buildkite-agent start") && kill $pid
+exit 0
             </string>
             <key>unattended_install</key>
             <true/>


### PR DESCRIPTION
`killall` was killing one too many processes that actually killed builds. This new method will only kill the correct process.

@grahamgilbert 