### PR TITLE
Add minimum_os_version to pkg_info

### DIFF
--- a/Crypt2/Crypt2.munki.recipe
+++ b/Crypt2/Crypt2.munki.recipe
@@ -23,6 +23,8 @@
             <string>Crypt is a Filevault 2 Escrow solution.</string>
             <key>name</key>
             <string>%NAME%</string>
+	    <key>minimum_os_version</key>
+	    <string>10.12</string>
             <key>unattended_install</key>
             <true/>
             <key>preuninstall_script</key>


### PR DESCRIPTION
- Crypt 3.0.0 deprecated support for macOS earlier than 10.12
- Add `minimum_os_version: 10.12` to pkg_info
