### PR TITLE
Crypt2 - convert from installs array to installcheck script

### DIFF
--- a/Crypt2/Crypt2.munki.recipe
+++ b/Crypt2/Crypt2.munki.recipe
@@ -185,17 +185,11 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/payload</string>
-                <key>installs_item_paths</key>
-                <array>
-                    <string>/Library/LaunchDaemons/com.grahamgilbert.crypt.plist</string>
-                    <string>/Library/Crypt/checkin</string>
-                    <string>/Library/Security/SecurityAgentPlugins/Crypt.bundle</string>
-                </array>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/payload/Library/Security/SecurityAgentPlugins/Crypt.bundle/Contents/Info.plist</string>
             </dict>
             <key>Processor</key>
-            <string>MunkiInstallsItemsCreator</string>
+            <string>Versioner</string>
         </dict>
         <dict>
             <key>Arguments</key>
@@ -214,6 +208,67 @@
             <string>MunkiPkginfoMerger</string>
             <key>Arguments</key>
             <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installcheck_script</key>
+                    <string>#!/usr/bin/python
+
+'''This installcheck script template evaluates the installed version
+of Crypt as well as if Crypt is included properly in the authdb.'''
+
+from subprocess import check_output
+from distutils.version import StrictVersion
+import plistlib
+import os
+
+def get_mechs():
+    '''returns a list of all current authdb mechs'''
+    cmd = ["/usr/bin/security", "authorizationdb", "read", "system.login.console"]
+    cur_mech_plist = plistlib.readPlistFromString(check_output(cmd))
+    mechs_only = cur_mech_plist['mechanisms']
+    return mechs_only
+
+def get_crypt_vers():
+    '''returns the installed version of the Crypt bundle'''
+    plist = plistlib.readPlist("/Library/Security/SecurityAgentPlugins/Crypt.bundle/Contents/Info.plist")
+    return plist["CFBundleShortVersionString"]
+
+def main():
+    '''Checks if Crypt is properly installed and up to date. Note that the version var
+    below is auto-substituted by AutoPkg - if you are adding this installcheck manually,
+    be sure to insert the proper version number.'''
+
+    pkg_vers = %version%
+
+    install_items = ['/Library/Security/SecurityAgentPlugins/Crypt.bundle',
+                     '/Library/LaunchDaemons/com.grahamgilbert.crypt.plist',
+                     '/Library/Crypt/checkin',
+                     '/Library/Security/SecurityAgentPlugins/Crypt.bundle']
+    for item in install_items:
+        if not os.path.exists(item):
+            # we are missing a needed file - Crypt is damaged or not installed
+            exit(0)
+
+    # check if Crypt is up to date
+    installed_vers = get_crypt_vers()
+    if StrictVersion(installed_vers) &lt; StrictVersion(pkg_vers):
+        # we are out of date compared to the pkg version
+        exit(0)
+
+    mechs = ['Crypt:Check,privileged', 'Crypt:CryptGUI', 'Crypt:Enablement,privileged']
+    current_mechs = get_mechs()
+    for crypt_mech in mechs:
+        if not crypt_mech in current_mechs:
+            # mechs are not in place
+            exit(0)
+
+    # all mechs in place and version is up to date
+    exit(1)
+
+if __name__ == "__main__":
+    main()
+				</string>
+				</dict>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Since munki evaluates either an installcheck script OR the installs array, the existing recipe did not allow admins to evaluate both the installed Crypt bundle version and the existence of the authdb mechanisms. This PR adds an installcheck script that compares both.