### PR TITLE
Add missing quotes

### DIFF
--- a/Crypt2/Crypt2.munki.recipe
+++ b/Crypt2/Crypt2.munki.recipe
@@ -238,7 +238,7 @@ def main():
     below is auto-substituted by AutoPkg - if you are adding this installcheck manually,
     be sure to insert the proper version number.'''
 
-    pkg_vers = %version%
+    pkg_vers = '%version%'
 
     install_items = ['/Library/Security/SecurityAgentPlugins/Crypt.bundle',
                      '/Library/LaunchDaemons/com.grahamgilbert.crypt.plist',


### PR DESCRIPTION
I should be shamed as I have forgotten to properly quote a variable in the installcheck. This would lead to a broken munki pkginfo.