### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Fantastical2/Fantastical2.install.recipe
+++ b/Fantastical2/Fantastical2.install.recipe
@@ -50,7 +50,7 @@
       						<key>destination_path</key>
       						<string>/Applications</string>
       						<key>source_item</key>
-      						<string>%NAME%.app</string>
+      						<string>Fantastical.app</string>
       					</dict>
       				</array>
       			</dict>

--- a/iStatMenus/iStatMenus.install.recipe
+++ b/iStatMenus/iStatMenus.install.recipe
@@ -50,7 +50,7 @@
       						<key>destination_path</key>
       						<string>/Applications</string>
       						<key>source_item</key>
-      						<string>%NAME%.app</string>
+      						<string>iStat Menus.app</string>
       					</dict>
       				</array>
       			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.