### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Blackboard/ParentCopier.py
+++ b/Blackboard/ParentCopier.py
@@ -16,13 +16,13 @@
 
 
 from __future__ import absolute_import
+
 import os.path
 import shutil
-
 from glob import glob
+
 from autopkglib import Processor, ProcessorError
 from autopkglib.DmgMounter import DmgMounter
-
 
 __all__ = ["ParentCopier"]
 
@@ -141,4 +141,3 @@ class ParentCopier(DmgMounter):
 if __name__ == '__main__':
     processor = ParentCopier()
     processor.execute_shell()
-    

--- a/Blackboard/ParentCopier.py
+++ b/Blackboard/ParentCopier.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import os.path
 import shutil
 
@@ -81,7 +82,7 @@ class ParentCopier(DmgMounter):
                     shutil.rmtree(dest_item)
                 else:
                     os.unlink(dest_item)
-            except OSError, err:
+            except OSError as err:
                 raise ProcessorError(
                     "Can't remove %s: %s" % (dest_item, err.strerror))
                     
@@ -94,7 +95,7 @@ class ParentCopier(DmgMounter):
             else:
                 shutil.copy(source_item, dest_item)
             self.output("Copied %s to %s" % (source_item, dest_item))
-        except BaseException, err:
+        except BaseException as err:
             raise ProcessorError(
                 "Can't copy %s to %s: %s" % (source_item, dest_item, err))
     

--- a/Buildkite/BuildkiteVersioner.py
+++ b/Buildkite/BuildkiteVersioner.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 

--- a/Buildkite/BuildkiteVersioner.py
+++ b/Buildkite/BuildkiteVersioner.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
 
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["BuildkiteVersioner"]
 

--- a/Puppetlabs/PuppetAgentProductsURLProvider.py
+++ b/Puppetlabs/PuppetAgentProductsURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for PuppetlabsProductsURLProvider class"""
 
+from __future__ import absolute_import
 import urllib2
 import re
 from distutils.version import LooseVersion

--- a/Puppetlabs/PuppetAgentProductsURLProvider.py
+++ b/Puppetlabs/PuppetAgentProductsURLProvider.py
@@ -16,6 +16,7 @@
 """See docstring for PuppetlabsProductsURLProvider class"""
 
 from __future__ import absolute_import
+
 import re
 from distutils.version import LooseVersion
 

--- a/Puppetlabs/PuppetAgentProductsURLProvider.py
+++ b/Puppetlabs/PuppetAgentProductsURLProvider.py
@@ -16,11 +16,15 @@
 """See docstring for PuppetlabsProductsURLProvider class"""
 
 from __future__ import absolute_import
-import urllib2
 import re
 from distutils.version import LooseVersion
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["PuppetAgentProductsURLProvider"]
 
@@ -73,7 +77,7 @@ class PuppetAgentProductsURLProvider(Processor):
         re_download = ("href=\"(puppet-agent-(%s)-1.osx(%s).dmg)\"" % (version_re, os_version))
 
         try:
-            data = urllib2.urlopen(download_url).read()
+            data = urlopen(download_url).read()
         except BaseException as err:
             raise ProcessorError(
                 "Unexpected error retrieving download index: '%s'" % err)

--- a/ShardOverTimeProcessor/ShardOverTimeProcessor.py
+++ b/ShardOverTimeProcessor/ShardOverTimeProcessor.py
@@ -3,6 +3,8 @@
 
 """See docstring for ShardOverTimeProcessor class"""
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import datetime
 from autopkglib import Processor, ProcessorError
@@ -52,8 +54,8 @@ class ShardOverTimeProcessor(Processor):
                 # It's a sunday
                 return the_date.replace(hour=9, minute=00) + datetime.timedelta(days=1)
             elif the_date.hour not in range(9,18):
-                print("{} is not between 9 and 18".format(the_date))
-                print("Sending {} back to next_working_day".format(the_date.replace(hour=9, minute=00) + datetime.timedelta(days=1)))
+                print(("{} is not between 9 and 18".format(the_date)))
+                print(("Sending {} back to next_working_day".format(the_date.replace(hour=9, minute=00) + datetime.timedelta(days=1))))
                 # The time is not in working hours, call ourself with tomorrow as the date
                 return self.next_working_day(the_date.replace(hour=9, minute=00) + datetime.timedelta(days=1))
             else:
@@ -101,7 +103,7 @@ class ShardOverTimeProcessor(Processor):
                 for group in range(0, 10):
                     group = (group + 1) * 10
                     deploy_time = self.next_working_day(current_deploy_date + increment)
-                    print("group: {} deploy_time: {}".format(group, deploy_time))
+                    print(("group: {} deploy_time: {}".format(group, deploy_time)))
                     output_string += "({} <= {} AND date > CAST(\"{}\", \"NSDate\")) OR ".format(condition, group, deploy_time.strftime(date_format))
                     current_deploy_date = deploy_time
                 output_string = output_string[:-4]

--- a/ShardOverTimeProcessor/ShardOverTimeProcessor.py
+++ b/ShardOverTimeProcessor/ShardOverTimeProcessor.py
@@ -3,12 +3,12 @@
 
 """See docstring for ShardOverTimeProcessor class"""
 
-from __future__ import absolute_import
-from __future__ import print_function
-import os
+from __future__ import absolute_import, division, print_function
+
 import datetime
-from autopkglib import Processor, ProcessorError
 import sys
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["ShardOverTimeProcessor"]
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.