### PR TITLE
Switch from CURL* back to URL* processors

### DIFF
--- a/outset/outset.download.recipe
+++ b/outset/outset.download.recipe
@@ -26,7 +26,7 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>CURLDownloader</string>
+            <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>


### PR DESCRIPTION
As of [AutoPkg 0.6.0](https://github.com/autopkg/autopkg/tree/v0.6.0), it's safe to switch back to the "standard" URLDownloader and URLTextSearcher processors.