### PR TITLE
Adjust PuppetAgentProductsURLProvider to use new URLGetter superclass

### DIFF
--- a/Puppetlabs/Puppet-Agent5.download.recipe
+++ b/Puppetlabs/Puppet-Agent5.download.recipe
@@ -19,7 +19,7 @@ OS_VERSION can be overridden, or left to the default, '10.12'.</string>
 		<string>5</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.1</string>
+	<string>1.4</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Puppetlabs/PuppetAgentProductsURLProvider.py
+++ b/Puppetlabs/PuppetAgentProductsURLProvider.py
@@ -20,12 +20,7 @@ from __future__ import absolute_import
 import re
 from distutils.version import LooseVersion
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.request import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["PuppetAgentProductsURLProvider"]
 
@@ -34,7 +29,7 @@ DEFAULT_VERSION = "latest"
 DEFAULT_PRODUCT_VERSION = "5"
 OS_VERSION = "10.12"
 
-class PuppetAgentProductsURLProvider(Processor):
+class PuppetAgentProductsURLProvider(URLGetter):
     """Extracts a URL for a Puppet Labs item."""
     description = __doc__
     input_variables = {
@@ -78,7 +73,7 @@ class PuppetAgentProductsURLProvider(Processor):
         re_download = ("href=\"(puppet-agent-(%s)-1.osx(%s).dmg)\"" % (version_re, os_version))
 
         try:
-            data = urlopen(download_url).read()
+            data = self.download(download_url)
         except BaseException as err:
             raise ProcessorError(
                 "Unexpected error retrieving download index: '%s'" % err)

--- a/Puppetlabs/PuppetAgentProductsURLProvider.py
+++ b/Puppetlabs/PuppetAgentProductsURLProvider.py
@@ -36,7 +36,8 @@ class PuppetAgentProductsURLProvider(URLGetter):
         "product_version": {
             "required": False,
             "description":
-                "Major version of the AIO installer. Either 5 or 6 at present. Defaults to %s".format(DEFAULT_PRODUCT_VERSION),
+                "Major version of the AIO installer. Either 5 or 6 at "
+                "present. Defaults to %s" % DEFAULT_PRODUCT_VERSION,
         },
         "get_version": {
             "required": False,


### PR DESCRIPTION
This new superclass will make the transition to Python 3.x / AutoPkg 2.x smoother, and uses the methodology documented here: https://github.com/autopkg/autopkg/wiki/Downloading-from-the-Internet-in-Custom-Processors

This PR also contains a minor fix: `.format()` was used where `%` should have been.