### PR TITLE
Fix pkg_payload_path in Crypt.munki

### DIFF
--- a/Crypt/Crypt.munki.recipe
+++ b/Crypt/Crypt.munki.recipe
@@ -48,7 +48,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/Crypt.pkg/Payload</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/payload</string>
             </dict>


### PR DESCRIPTION
Fixes #6 for the Crypt.munki recipe.