### PR TITLE
Clean up installs_item_paths

### DIFF
--- a/Sal/Sal.munki.recipe
+++ b/Sal/Sal.munki.recipe
@@ -65,25 +65,7 @@
                     <string>/usr/local/munki/postflight</string>
                     <string>/usr/local/munki/preflight</string>
                     <string>/usr/local/munki/postflight.d/sal-postflight</string>
-                    <string>/usr/local/munki/postflight.d/sal-preflight</string>
-                    <string>/usr/local/sal/yaml/__init__.py</string>
-                    <string>/usr/local/sal/yaml/composer.py</string>
-                    <string>/usr/local/sal/yaml/constructor.py</string>
-                    <string>/usr/local/sal/yaml/cyaml.py</string>
-                    <string>/usr/local/sal/yaml/dumper.py</string>
-                    <string>/usr/local/sal/yaml/emitter.py</string>
-                    <string>/usr/local/sal/yaml/error.py</string>
-                    <string>/usr/local/sal/yaml/events.py</string>
-                    <string>/usr/local/sal/yaml/loader.py</string>
-                    <string>/usr/local/sal/yaml/nodes.py</string>
-                    <string>/usr/local/sal/yaml/parser.py</string>
-                    <string>/usr/local/sal/yaml/reader.py</string>
-                    <string>/usr/local/sal/yaml/representer.py</string>
-                    <string>/usr/local/sal/yaml/resolver.py</string>
-                    <string>/usr/local/sal/yaml/scanner.py</string>
-                    <string>/usr/local/sal/yaml/serializer.py</string>
-                    <string>/usr/local/sal/yaml/tokens.py</string>
-                    <string>/usr/local/sal/utils.py</string>
+                    <string>/usr/local/munki/preflight.d/sal-preflight</string>
                 </array>
             </dict>
             <key>Processor</key>


### PR DESCRIPTION
It just caught my eye that the 'installs_item_paths' in the MunkiInstallsItemsCreator has some '/usr/local/sal/yaml' paths, which were needed for sal-scripts 2, but no longer for sal-scripts 3, because these paths have been moved to puppet_checkin_module (which I can't get to work atm, but I'll make a separate issue for that later). There was also a typo (/usr/local/munki/postflight.d was listed twice). This patch cleans up the installs_item_paths and fixes the typo, and should not affect the functionality of this recipe.