### PR TITLE
Update Sal.munki.recipe

### DIFF
--- a/Sal/Sal.munki.recipe
+++ b/Sal/Sal.munki.recipe
@@ -66,6 +66,7 @@
                     <string>/usr/local/munki/preflight</string>
                     <string>/usr/local/munki/postflight.d/sal-postflight</string>
                     <string>/usr/local/munki/preflight.d/sal-preflight</string>
+                    <string>/usr/local/sal/bin/sal-submit</string>
                 </array>
             </dict>
             <key>Processor</key>


### PR DESCRIPTION
In the latest release there were no changes to the items in installs_item_paths, resulting in Munki/MSC showing no updates.
There were changes to sal-submit, I manually added it to pkgsinfo plist, which solved that immediate need for us.
By adding /usr/local/sal/bin/sal-submit to installs_item_paths others may not have the same issue.

Please accept my humble edit to the project.