### PR TITLE
Updating for Outset 3's Distribution Package

### DIFF
--- a/outset/outset.munki.recipe
+++ b/outset/outset.munki.recipe
@@ -49,8 +49,17 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/outset-*.component.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
+                <string>%found_filename%/Payload</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/payload</string>
             </dict>


### PR DESCRIPTION
Currently outset.munki is failing due to the improper path to the package payload.