### PR TITLE
Update outset.munki.recipe

### DIFF
--- a/outset/outset.munki.recipe
+++ b/outset/outset.munki.recipe
@@ -26,7 +26,7 @@
             <key>unattended_install</key>
             <true/>
             <key>minimum_os_version</key>
-            <string>10.9.0</string>
+            <string>10.15</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
Per Github release notes, outset 3.x now requires macOS 10.15+