### PR TITLE
Remove unused BUNDLE_ID input var and fix parent recipe identifiers

### DIFF
--- a/Google/BackupandSync.install.recipe
+++ b/Google/BackupandSync.install.recipe
@@ -14,7 +14,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.grahamgilbert.BackupandSync</string>
+	<string>com.github.grahamgilbert.download.BackupandSync</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Google/BackupandSync.pkg.recipe
+++ b/Google/BackupandSync.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.grahamgilbert.pkg.BackupandSync</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.google.GoogleDrive</string>
 		<key>NAME</key>
 		<string>Backup and Sync</string>
 	</dict>

--- a/Google/BackupandSync.pkg.recipe
+++ b/Google/BackupandSync.pkg.recipe
@@ -14,7 +14,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.grahamgilbert.BackupandSync</string>
+	<string>com.github.grahamgilbert.download.BackupandSync</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Sim Daltonism/Sim Daltonism.pkg.recipe
+++ b/Sim Daltonism/Sim Daltonism.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.grahamgilbert.SimDaltonism.pkg</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.michelf.sim-daltonism</string>
 		<key>NAME</key>
 		<string>Sim Daltonism</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Parent recipe identifiers for the Google Backup and Sync recipes have also been corrected.

Recipe run output is included below for all changed pkg recipes.

## ✅ Google/BackupandSync.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/grahamgilbert-recipes/Google/BackupandSync.pkg.recipe
Processing repos/grahamgilbert-recipes/Google/BackupandSync.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Backup and Sync.dmg',
           'url': 'https://dl.google.com/drive/InstallBackupAndSync.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.grahamgilbert.pkg.BackupandSync/downloads/Backup and Sync.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.grahamgilbert.pkg.BackupandSync/downloads/Backup '
                        'and Sync.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.grahamgilbert.pkg.BackupandSync/downloads/Backup '
                         'and Sync.dmg/Backup and Sync.app',
           'requirement': 'identifier "com.google.GoogleDrive" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'EQHXZ8M8AV'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahamgilbert.pkg.BackupandSync/downloads/Backup and Sync.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.NuQlUm/Backup and Sync.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.NuQlUm/Backup and Sync.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.NuQlUm/Backup and Sync.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.grahamgilbert.pkg.BackupandSync/downloads/Backup '
                               'and Sync.dmg/Backup and '
                               'Sync.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahamgilbert.pkg.BackupandSync/downloads/Backup and Sync.dmg
Versioner: Found version 3.54 in file /private/tmp/dmg.AjQAyS/Backup and Sync.app/Contents/Info.plist
{'Output': {'version': '3.54'}}
AppPkgCreator
{'Input': {'version': '3.54'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grahamgilbert.pkg.BackupandSync/downloads/Backup and Sync.dmg
AppPkgCreator: Using path '/private/tmp/dmg.NsBitx/Backup and Sync.app' matched from globbed '/private/tmp/dmg.NsBitx/*.app'.
AppPkgCreator: BundleID: com.google.GoogleDrive
AppPkgCreator: Copied /private/tmp/dmg.NsBitx/Backup and Sync.app to ~/Library/AutoPkg/Cache/com.github.grahamgilbert.pkg.BackupandSync/payload/Applications/Backup and Sync.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.google.GoogleDrive',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahamgilbert.pkg.BackupandSync/Backup '
                                                                    'and '
                                                                    'Sync-3.54.pkg',
                                                        'version': '3.54'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.54'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahamgilbert.pkg.BackupandSync/receipts/BackupandSync.pkg-receipt-20210213-225216.plist

The following packages were built:
    Identifier              Version  Pkg Path                                                                                                  
    ----------              -------  --------                                                                                                  
    com.google.GoogleDrive  3.54     ~/Library/AutoPkg/Cache/com.github.grahamgilbert.pkg.BackupandSync/Backup and Sync-3.54.pkg  
```

## ✅ Sim Daltonism/Sim Daltonism.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/grahamgilbert-recipes/Sim\ Daltonism/Sim\ Daltonism.pkg.recipe
Processing repos/grahamgilbert-recipes/Sim Daltonism/Sim Daltonism.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '[^"]+\\.zip',
           'url': 'https://littoral.michelf.ca/apps/sim-daltonism/?C=M;O=D'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): sim-daltonism-2.0.5.zip
{'Output': {'match': 'sim-daltonism-2.0.5.zip'}}
URLDownloader
{'Input': {'filename': 'Sim Daltonism.zip',
           'url': 'https://littoral.michelf.ca/apps/sim-daltonism/sim-daltonism-2.0.5.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/downloads/Sim Daltonism.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/downloads/Sim '
                        'Daltonism.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/downloads/Sim '
                           'Daltonism.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim '
                               'Daltonism',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Sim Daltonism.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/downloads/Sim Daltonism.zip to ~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim Daltonism
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim '
                         'Daltonism/Sim Daltonism.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.michelf.sim-daltonism" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = R5LCPCXJPZ)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim Daltonism/Sim Daltonism.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim Daltonism/Sim Daltonism.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim Daltonism/Sim Daltonism.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim '
                               'Daltonism/Sim '
                               'Daltonism.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 2.0.5 in file ~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim Daltonism/Sim Daltonism.app/Contents/Info.plist
{'Output': {'version': '2.0.5'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim '
                       'Daltonism/Sim Daltonism.app',
           'version': '2.0.5'}}
AppPkgCreator: BundleID: com.michelf.sim-daltonism
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim Daltonism/Sim Daltonism.app to ~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/payload/Applications/Sim Daltonism.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.michelf.sim-daltonism',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim '
                                                                    'Daltonism-2.0.5.pkg',
                                                        'version': '2.0.5'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.0.5'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/receipts/Sim Daltonism.pkg-receipt-20210213-225221.plist

The following packages were built:
    Identifier                 Version  Pkg Path                                                                                                
    ----------                 -------  --------                                                                                                
    com.michelf.sim-daltonism  2.0.5    ~/Library/AutoPkg/Cache/com.github.grahamgilbert.SimDaltonism.pkg/Sim Daltonism-2.0.5.pkg  
```

