### PR TITLE
Update default Munki Python path for Crypt

### DIFF
--- a/Crypt/Crypt.munki.recipe
+++ b/Crypt/Crypt.munki.recipe
@@ -14,7 +14,7 @@
         <key>NAME</key>
         <string>Crypt2</string>
         <key>PYTHON3PATH</key>
-        <string>/usr/local/munki/python</string>
+        <string>/usr/local/munki/munki-python</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>


### PR DESCRIPTION
Munki changed from using `/usr/local/munki/python` to using /usr/local/munki/munki-python`