### PR TITLE
Update Crypt preuninstall script for Python 3

### DIFF
--- a/Crypt/Crypt.munki.recipe
+++ b/Crypt/Crypt.munki.recipe
@@ -30,122 +30,105 @@
             <key>unattended_install</key>
             <true/>
             <key>preuninstall_script</key>
-	        <string>#!/usr/bin/python
+	        <string>#!%PYTHON3PATH%
 
-        # Copyright 2015 Crypt Project.
-        #
-        # Licensed under the Apache License, Version 2.0 (the "License");
-        # you may not use this file except in compliance with the License.
-        # You may obtain a copy of the License at
-        #
-        # http://www.apache.org/licenses/LICENSE-2.0
-        #
-        # Unless required by applicable law or agreed to in writing, software
-        # distributed under the License is distributed on an "AS IS" BASIS,
-        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        # See the License for the specific language governing permissions and
-        # limitations under the License.
+# Copyright 2015 Crypt Project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-        import  os,     \
-                sys,     \
-                plistlib,  \
-                platform,   \
-                subprocess
-        from    subprocess import Popen, \
-                                  PIPE,   \
-                                  STDOUT
+import  os,     \
+        sys,     \
+        plistlib,  \
+        platform,   \
+        subprocess
+from    subprocess import Popen, \
+                          PIPE,   \
+                          STDOUT
 
-        ##
-        ## mech_list: A list of strings. The list of mechs to add
-        ## index_mech: A string. The mech already in the DB, your mech_list will be installed above or below the index_mech
-        ## index_offset: An integer. Used to position the mech_list above or below the index_mech. 0 will be directly above,
-        ## 1 will be directly below. -1 would have one space between the mech_list and the index_mech etc...
-        ##
+## Path to system.login.console.plist
+system_login_console_plist = "/private/var/tmp/system.login.console.plist"
 
-        ##
-        ## Currently the FV2AuthPlugin only runs at the Login Window.
-        ## I may add support for Screen Saver unlock. There are stubs for
-        ## the authenticate db in place because of this.
-        ##
 
-        ## Path to system.login.console.plist
-        system_login_console_plist = "/private/var/tmp/system.login.console.plist"
+## Mechs that support FV2AuthPlugin
+fv2_mechs = ["Crypt:Check,privileged","Crypt:CryptGUI","Crypt:Enablement,privileged"]
 
-        ## Path to authenticate.plist
-        #authenticate_plist = "/private/var/tmp/authenticate.plist"
+def remove_mechs_in_db(db, mech_list):
+    for mech in mech_list:
+        for old_mech in filter(lambda x: mech in x, db['mechanisms']):
+            db['mechanisms'].remove(old_mech)
+    return db
 
-        ## Mechs that support FV2AuthPlugin
-        fv2_mechs = ["Crypt:Check,privileged","Crypt:CryptGUI","Crypt:Enablement,privileged"]
-        fv2_index_mech = "loginwindow:done"
-        fv2_index_offset = 0
+def set_mechs_in_db(db, mech_list):
+    ## Clear away any previous configs
+    db = remove_mechs_in_db(db, mech_list)
+    return db
 
-        def bash_command(script):
-            try:
-                return subprocess.check_output(script)
-            except (subprocess.CalledProcessError, OSError), err:
-                sys.exit("[* Error] **%s** [%s]" % (err, str(script)))
+def edit_authdb():
+    ## Export "system.login.console"
+    cmd = ["/usr/bin/security", "authorizationdb", "read", "system.login.console"]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        encoding='utf8')
+    stdout, stderr = proc.communicate()
+    # Even if the command succeeds, there may be an "error" of "YES (0)"
+    if stderr and "YES (0)" not in stderr:
+        sys.exit(f"\n{stderr}")
+    system_login_console = stdout
+    f_c = open(system_login_console_plist, 'w')
+    f_c.write(system_login_console)
+    f_c.close()
 
-        def remove_mechs_in_db(db, mech_list):
-            for mech in mech_list:
-                for old_mech in filter(lambda x: mech in x, db['mechanisms']):
-                    db['mechanisms'].remove(old_mech)
-            return db
+    ## Parse the plist
+    try:
+        plist_file = open(system_login_console_plist, 'r+b')
+    except:
+        sys.exit("\nCannot open system login console plist")
+    try:
+        plist_contents = plistlib.load(plist_file)
+    except:
+        sys.exit("\nCannot read contents of system login console plist")
+    plist_contents = set_mechs_in_db(plist_contents, fv2_mechs)
 
-        def set_mechs_in_db(db, mech_list, index_mech, index_offset):
-            ## Clear away any previous configs
-            db = remove_mechs_in_db(db, mech_list)
+    # Empty file before writing back to it
+    plist_file.seek(0)
+    plist_file.truncate()
+    ## Write back the changes
+    plistlib.dump(plist_contents, plist_file)
+    plist_file.close()
 
-            ## Add mech_list to db
-            # i = int(db['mechanisms'].index(index_mech)) + index_offset
-            # for mech in mech_list:
-            #     db['mechanisms'].insert(i, mech)
-            #     i += 1
-            return db
+    try:
+        plist_file = open(system_login_console_plist, "r")
+    except:
+        sys.exit("\nUnable to open system login console plist to read changes")
+    # Avoid str instead of bytes-like error messages
+    lines = plist_file.readlines()
+    plist_data = ''
+    for line in lines:
+        plist_data += line
+    plist_data = plist_data.encode()
+    proc = Popen(["/usr/bin/security", "authorizationdb", "write", "system.login.console"], stdout=PIPE, stdin=PIPE, stderr=PIPE)
+    stdout_data = proc.communicate(input=plist_data)
+    plist_file.close()
 
-        def edit_authdb():
-            ## Export "system.login.console"
-            system_login_console = bash_command(["/usr/bin/security", "authorizationdb", "read", "system.login.console"])
-            f_c = open(system_login_console_plist, 'w')
-            f_c.write(system_login_console)
-            f_c.close()
+def check_root():
+    if not os.geteuid() == 0:
+        sys.exit("\nOnly root can run this script\n")
 
-            ## Export "authenticate"
-            #authenticate = bash_command(["/usr/bin/security", "authorizationdb", "read", "authenticate"])
-            #f_a = open(authenticate_plist, 'w')
-            #f_a.write(authenticate)
-            #f_a.close()
+def main(argv):
+    #check_root()
+    edit_authdb()
 
-            ## Leave the for loop. Possible support for ScreenSaver unlock
-            for p in [system_login_console_plist]:
-                ## Parse the plist
-                d = plistlib.readPlist(p)
-
-                ## Add FV2 mechs
-                d = set_mechs_in_db(d, fv2_mechs, fv2_index_mech, fv2_index_offset)
-
-                ## Write out the changes
-                plistlib.writePlist(d, p)
-
-            f_c = open(system_login_console_plist, "r")
-            p = Popen(["/usr/bin/security", "authorizationdb", "write", "system.login.console"], stdout=PIPE, stdin=PIPE, stderr=PIPE)
-            stdout_data = p.communicate(input=f_c.read())
-            f_c.close()
-
-            #f_a = open(authenticate_plist, "r")
-            #p = Popen(["/usr/bin/security", "authorizationdb", "write", "authenticate"], stdout=PIPE, stdin=PIPE, stderr=PIPE)
-            #stdout_data = p.communicate(input=f_a.read())
-            #f_a.close()
-
-        def check_root():
-            if not os.geteuid() == 0:
-                sys.exit("\nOnly root can run this script\n")
-
-        def main(argv):
-            check_root()
-            edit_authdb()
-
-        if __name__ == '__main__':
-            main(sys.argv)
+if __name__ == '__main__':
+    main(sys.argv)
         </string>
         </dict>
     </dict>


### PR DESCRIPTION
Since Python 2 was end of life in 2020 and Apple is removing `/usr/bin/python` in 12.3, we should update this script.