### PR TITLE
Add version to Outset pkg name

### DIFF
--- a/outset/outset.download.recipe
+++ b/outset/outset.download.recipe
@@ -27,11 +27,6 @@
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>filename</key>
-                <string>%NAME%.pkg</string>
-            </dict>
         </dict>
         <dict>
             <key>Processor</key>


### PR DESCRIPTION
The current recipe to download Outset overrides the name the Github repo gives the installer pkg (e.g., outset-3.0.3.pkg). It is a convention with many AutoPkg users to name their pkg installers NAME-version before they upload them to their management system. Since Github provides a pkg name that adheres to this convention, deleting the `filename` argument provides this for free. This should not have any effect on child recipes that do not depend on the name being NAME.pkg, but I do not have a Munki setup to test.