### PR TITLE
Add code signature verification for Sal scripts

### DIFF
--- a/Sal/Sal.download.recipe
+++ b/Sal/Sal.download.recipe
@@ -37,6 +37,21 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+        <key>Arguments</key>
+        <dict>
+            <key>input_path</key>
+            <string>%pathname%</string>
+            <key>expected_authority_names</key>
+            <array>
+                <string>Developer ID Installer: Graham Gilbert (9D8XP85393)</string>
+                <string>Developer ID Certification Authority</string>
+                <string>Apple Root CA</string>
+            </array>
+        </dict>
+        <key>Processor</key>
+        <string>CodeSignatureVerifier</string>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
I was auditing some AutoPkg recipes and noticed this one was missing the signature check.