### PR TITLE
Add code sig verification to outset.download

### DIFF
--- a/outset/outset.download.recipe
+++ b/outset/outset.download.recipe
@@ -32,6 +32,21 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%pathname%</string>
+			</dict>
+		</dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
When #46 was merged to adopt the Swift version of outset, the source download became a signed pkg (the chilcote original pkg was unsigned). This PR adds code signature verification.