### PR TITLE
Add more info about versions if the proper version not installed for Crypt Munki recipe

### DIFF
--- a/Crypt/Crypt.munki.recipe
+++ b/Crypt/Crypt.munki.recipe
@@ -109,12 +109,12 @@ checkin_version=$(/Library/Crypt/checkin -version)
 
 desired_version="%version%"
 if is_version_gt $desired_version $plugin_version; then
-    echo "Plugin version is lower than desired version"
+    echo "Plugin version $plugin_version is lower than desired version $desired_version"
     exit 0
 fi
 
 if is_version_gt $desired_version $checkin_version; then
-    echo "Checkin version is lower than desired version"
+    echo "Checkin version $checkin_version is lower than desired version $desired_version"
     exit 0
 fi
 


### PR DESCRIPTION
Adds actual version mismatch details to the installcheck_script if the version doesn't match.