### PR TITLE
Remove extra whitespace in Crypt.munki.recipe

### DIFF
--- a/Crypt/Crypt.munki.recipe
+++ b/Crypt/Crypt.munki.recipe
@@ -95,8 +95,8 @@ function exit_if_path_not_exist() {
     fi
 }
 
-function is_version_gt() { 
-    test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; 
+function is_version_gt() {
+    test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
 }
 
 # Make sure the paths exist


### PR DESCRIPTION
Hey Graham! We're implementing [pre-commit](https://pre-commit.com/), and these two lines are modified by the `trailing-whitespace` hook. This PR makes the same changes to the recipe, so we're not fixing it locally in future releases of Crypt.