### PR TITLE
Fix Crypt munki recipe for v6 distribution package structure

### DIFF
--- a/Crypt/Crypt.munki.recipe
+++ b/Crypt/Crypt.munki.recipe
@@ -50,7 +50,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/Crypt.pkg/Payload</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/payload</string>
             </dict>


### PR DESCRIPTION
## Summary

- Crypt v6 changed from a flat component package to a distribution package
- After `FlatPkgUnpacker` expands the outer wrapper, the component payload is now at `Crypt.pkg/Payload` rather than directly at `Payload`
- Updates `pkg_payload_path` in `PkgPayloadUnpacker` to reflect the new structure

## Test plan

- [ ] Downloaded `Crypt-6.0.0.299.pkg` (v6 prerelease) and manually confirmed the expanded structure contains `Crypt.pkg/Payload`
- [ ] Ran `autopkg run Crypt/Crypt.munki.recipe -v` — `FlatPkgUnpacker`, `PkgPayloadUnpacker`, and `Versioner` all succeed; only fails at `MunkiImporter` due to no local Munki repo (expected)
- [ ] Confirmed v5 (`Crypt.pkg`) also expands with the same nested structure, so this fix is backwards compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)