### PR TITLE
[codex] Fix Crypt munki recipe plist escaping

### DIFF
--- a/Crypt/Crypt.munki.recipe
+++ b/Crypt/Crypt.munki.recipe
@@ -105,7 +105,7 @@ plugin_version=$(defaults read /Library/Security/SecurityAgentPlugins/Crypt.bund
 file_type=$(/usr/bin/file -b --mime-type /Library/Crypt/checkin | /usr/bin/sed 's|/.*||')
 
 if [ "$file_type" = "text" ]; then
-    echo "Checkin version is < Crypt 5"
+    echo "Checkin version is &lt; Crypt 5"
     exit 0
 else
     checkin_version=$(/Library/Crypt/checkin -version)


### PR DESCRIPTION
## Summary

Fixes the invalid XML in `Crypt/Crypt.munki.recipe` by escaping a literal less-than sign inside the embedded `installcheck_script` string.

## Root cause

The recipe contained `echo "Checkin version is < Crypt 5"` inside a plist `<string>`. The raw `<` is not valid character data in XML, so plist parsers report the recipe as not well formed.

## Impact

AutoPkg should no longer warn or crash while parsing this recipe. The parsed script output remains the same because `&lt;` is decoded back to `<` when the plist is read.

Fixes #63.

## Validation

- `plutil -lint Crypt/Crypt.munki.recipe`
- `for f in **/*.recipe; do plutil -lint "$f" >/dev/null || exit 1; done`