### PR TITLE
Use APLooseVersion instead of distutils

### DIFF
--- a/Puppetlabs/Puppet-Agent5.download.recipe
+++ b/Puppetlabs/Puppet-Agent5.download.recipe
@@ -19,7 +19,7 @@ OS_VERSION can be overridden, or left to the default, '10.12'.</string>
 		<string>5</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.4</string>
+	<string>2.0.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Puppetlabs/Puppet-Agent5.munki.recipe
+++ b/Puppetlabs/Puppet-Agent5.munki.recipe
@@ -39,7 +39,7 @@ specifically for each OS, we're setting the 'minimum_os_version' and 'maximum_os
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.1</string>
+	<string>2.0.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.grahamgilbert.download.puppet-agent5</string>
 	<key>Process</key>

--- a/Puppetlabs/PuppetAgentProductsURLProvider.py
+++ b/Puppetlabs/PuppetAgentProductsURLProvider.py
@@ -18,8 +18,8 @@
 from __future__ import absolute_import
 
 import re
-from distutils.version import LooseVersion
 
+from autopkglib import APLooseVersion as LooseVersion
 from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["PuppetAgentProductsURLProvider"]


### PR DESCRIPTION
AutoPkg has provided `APLooseVersion` since version 2.0.1 as a drop-in replacement for `distutils.version.LooseVersion` with identical comparison semantics for the specific use cases in this repo.

This PR updates your processor and any consuming recipes to leverage `APLooseVersion` for version comparison, which enables your recipe(s) to continue working with a future version of AutoPkg that includes a Python 3.12 or 3.13 runtime and drops `distutils`.
